### PR TITLE
added clearPreview method

### DIFF
--- a/src/components/Vue3Dropzone.vue
+++ b/src/components/Vue3Dropzone.vue
@@ -143,7 +143,7 @@ const props = defineProps({
     default: 'replace'
   },
 })
-const emit = defineEmits(['drop', 'update:modelValue'])
+const emit = defineEmits(['drop', 'update:modelValue', 'error'])
 
 const fileInput = ref(null)
 const files = ref([])

--- a/src/components/Vue3Dropzone.vue
+++ b/src/components/Vue3Dropzone.vue
@@ -87,7 +87,7 @@
 </template>
 
 <script setup>
-import {computed, onBeforeUnmount, onMounted, ref, watchEffect} from "vue";
+import {computed, defineExpose, ref, watchEffect} from "vue";
 import Icon from "./Icon.vue";
 
 const props = defineProps({
@@ -242,6 +242,7 @@ const drop = (e) => {
 const removeImg = (item) => {
   previewUrls.value = previewUrls.value.filter(url => url.id !== item.id)
   files.value = files.value.filter(file => file.id !== item.id)
+  fileInput.value.value = ''
   emit('update:modelValue', files.value)
 }
 
@@ -282,6 +283,13 @@ watchEffect(() => {
   }
 })
 
+const clearPreview = () => {
+  previewUrls.value.forEach(img => removeImg(img))
+};
+
+defineExpose({
+  clearPreview
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
Added a `clearPreview` method which can be used by `$refs.dropzone.clearPreview()` to clear the preview images after the upload handler has processed the images.

Also added a clearance for the file input in order to be able to upload the same file again.

Cleared up unused imports (onBeforeMount, onMounted).