### PR TITLE
Add instructions to override the component slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Local registration:
 | `placeholder-img` | `undefined` |
 | `title`           | `undefined` |
 
+## Customizing Slots
+
+You can easily customize the component by overriding the available slots. Below is an example of how to use the different slots (button, placeholder-img, title, description) to personalize the behavior and appearance of the component.
+
 ```jsx
 <Vue3Dropzone v-model="files">
   <template #placeholder-img>

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Local registration:
 | `placeholder-img` | `undefined` |
 | `title`           | `undefined` |
 
+```jsx
+<Vue3Dropzone v-model="files">
+  <template #placeholder-img><img src='your-custom-image'></template>
+  <template #titles> Your Custom Title </template>
+  <template #button="{ fileInput }">
+    <button @click="fileInput?.click()" class="custom-button">Your Custom Select Button</button>
+  </template>
+  <template #description>Your Custom Description</template>
+</Vue3Dropzone>
+```
+
 ## Css variables
 
 | Name                             | Value           |    

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Local registration:
 
 ```jsx
 <Vue3Dropzone v-model="files">
-  <template #placeholder-img><img src='your-custom-image'></template>
+  <template #placeholder-img>
+    <img src="your-custom-image" />
+  </template>
   <template #titles> Your Custom Title </template>
   <template #button="{ fileInput }">
     <button @click="fileInput?.click()" class="custom-button">Your Custom Select Button</button>

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can easily customize the component by overriding the available slots. Below 
   <template #placeholder-img>
     <img src="your-custom-image" />
   </template>
-  <template #titles> Your Custom Title </template>
+  <template #title>Your Custom Title</template>
   <template #button="{ fileInput }">
     <button @click="fileInput?.click()" class="custom-button">Your Custom Select Button</button>
   </template>


### PR DESCRIPTION
It was missing or not very clear in the documentation how to override the slots.
It is worth mentioning that there are examples on the demo page, but I think it is important to make this clear directly in the README.md.