### PR TITLE
Improve file size calculation in preview component.

### DIFF
--- a/src/components/Vue3Dropzone.vue
+++ b/src/components/Vue3Dropzone.vue
@@ -65,7 +65,7 @@
                   </svg>
                 </button>
                 <h2>{{ img.name }}</h2>
-                <span>{{ (img.size / 1024 / 1024).toFixed(2) }}MB</span>
+                <span>{{ formatSize(img.size) }}</span>
               </div>
             </div>
           </slot>
@@ -215,6 +215,12 @@ const inputFiles = (e) => {
     })
   })
   previewUrls.value = generatedUrls;
+}
+
+// Formats file size
+const formatSize = (size) => {
+    const i = Math.floor(Math.log(size) / Math.log(1024));
+    return (size / Math.pow(1024, i)).toFixed(2) * 1 + ' ' + ['B', 'KB', 'MB', 'GB'][i];
 }
 
 // Toggles active state for dropping files(styles)


### PR DESCRIPTION
Replaced the existing file size calculation {{ (img.size / 1024 / 1024).toFixed(2) }}MB with a new function {{ fileSize(img.size) }} that provides a more accurate representation of file sizes in KB, MB, GB, etc. This enhancement allows for better readability and usability for users when viewing file sizes.