### PR TITLE
Enhance Documentation and Move Preview Logic to Child Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ Local registration:
 | ------- | --------- | --------------------------------------------------------------------------------- |
 | `error` | `Array`   | Emits the error event and also provides data to know which files caused the error |
 
-### Example
-
 To capture the error event, you can use the `@error` event handler on the component. Here is an example of how to implement this:
 
 ```vue
@@ -95,6 +93,38 @@ function handleError(error) {
     console.error(`The following files are not accepted formats: ${files.map(file => file.name).join(', ')}`);
   }
 }
+</script>
+```
+
+## Server-Side File Upload
+
+To enable the server-side file upload functionality, you can use the following props:
+
+| Prop          | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `server-side` | `true` or `false`.                                |
+| `endpoint`    | The URL endpoint where the file will be uploaded. |
+| `headers`     | An object that contains any additional headers.   |
+
+```vue
+<template>
+  <Vue3Dropzone
+    v-model="files"
+    :server-side="true"
+    endpoint="http://your-endpoint"
+    :headers="headers"
+  />
+</template>
+
+<script setup>
+import { ref, computed } from "vue";
+
+const files = ref([]);
+const headers = computed(() => {
+  return {
+    Authorization: "Bearer " + localStorage.getItem("token"),
+  };
+});
 </script>
 ```
 
@@ -137,7 +167,7 @@ The preview slot allows for more complex customization of how uploaded files are
 |              | - `id`: The unique identifier for the file.                         |
 |              | - `src`: The URL or preview of the file.                            |
 |              | - `progress`: The progress of the file upload (percentage).         |
-|              | - `status`: `pending`, `uploading`, `success`, or `error`.          |
+|              | - `status`: `pending`, `uploading`, `success`, `error`.             |
 |              | - `message`: An error or success message regarding the file upload. |
 | `formatSize` | format the file size (e.g., KB, MB, GB).                            |
 | `removeFile` | remove the uploaded file from the list.                             |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Local registration:
 ## Props
 
 | Prop                    | Type              | Default   | Note                                                                  |
-|-------------------------|-------------------|-----------|-----------------------------------------------------------------------|
+| ----------------------- | ----------------- | --------- | --------------------------------------------------------------------- |
 | `modelValue`            | `Array`           | []        | 2 way binding ref                                                     |
 | `multiple`              | `Boolean`         | false     | Makes dropzone accept multiple files                                  |
 | `previews`              | `Array`           | []        | Preview images links (works with mode props)                          |
@@ -73,7 +73,7 @@ Local registration:
 ## Events
 
 | Prop    | Data Type | Note                                                                              |
-|---------|-----------|-----------------------------------------------------------------------------------|
+| ------- | --------- | --------------------------------------------------------------------------------- |
 | `error` | `Array`   | Emits the error event and also provides data to know which files caused the error |
 
 ### Example
@@ -100,13 +100,13 @@ function handleError(error) {
 
 ## Slots
 
-| Name              | data        |    
-|-------------------|-------------|
-| `button`          | `fileInput` |
-| `preview`         | `data`      |
-| `description`     | `undefined` |
-| `placeholder-img` | `undefined` |
-| `title`           | `undefined` |
+| Name              | data                             |
+| ----------------- | -------------------------------- |
+| `button`          | `fileInput`                      |
+| `preview`         | `data`,`formatSize`,`removeFile` |
+| `description`     | `undefined`                      |
+| `placeholder-img` | `undefined`                      |
+| `title`           | `undefined`                      |
 
 ## Customizing Slots
 
@@ -125,10 +125,39 @@ You can easily customize the component by overriding the available slots. Below 
 </Vue3Dropzone>
 ```
 
+## Using the Preview Slot
+
+The preview slot allows for more complex customization of how uploaded files are displayed. This slot provides three props: data, formatSize, and removeFile.
+
+### Props
+
+| Prop         | Description                                                         |
+| ------------ | ------------------------------------------------------------------- |
+| `data`       | - `file`: The File object.                                          |
+|              | - `id`: The unique identifier for the file.                         |
+|              | - `src`: The URL or preview of the file.                            |
+|              | - `progress`: The progress of the file upload (percentage).         |
+|              | - `status`: `pending`, `uploading`, `success`, or `error`.          |
+|              | - `message`: An error or success message regarding the file upload. |
+| `formatSize` | format the file size (e.g., KB, MB, GB).                            |
+| `removeFile` | remove the uploaded file from the list.                             |
+
+```jsx
+<Vue3Dropzone v-model="files">
+  <template #preview="{ data, formatSize, removeFile }">
+    <div class="your-custom-preview">
+      <h2>{{ data.file.name }}</h2>
+      <span>{{ formatSize(data.file.size) }}</span>
+      <button @click="removeFile(data)">Remove File</button>
+    </div>
+  </template>
+</Vue3Dropzone>
+```
+
 ## Css variables
 
-| Name                             | Value           |    
-|----------------------------------|-----------------|
+| Name                             | Value           |
+| -------------------------------- | --------------- |
 | `--v3-dropzone--primary`         | `94, 112, 210`  |
 | `--v3-dropzone--border`          | `214, 216, 220` |
 | `--v3-dropzone--description`     | `190, 191, 195` |

--- a/README.md
+++ b/README.md
@@ -85,19 +85,14 @@ To capture the error event, you can use the `@error` event handler on the compon
   <Vue3Dropzone v-model="files" @error="handleError" />
 </template>
 
-<script>
-export default {
-  methods: {
-    handleError(error) {
-      // Destructure the error object
-      const { type, files } = error;
+<script setup>
+function handleError(error) {
+  const { type, files } = error;
 
-      if (type === 'file-too-large') {
-        console.error(`The following files are too large: ${files.map(file => file.name).join(', ')}`);
-      } else if (type === 'invalid-file-format') {
-        console.error(`The following files are not accepted formats: ${files.map(file => file.name).join(', ')}`);
-      }
-    }
+  if (type === 'file-too-large') {
+    console.error(`The following files are too large: ${files.map(file => file.name).join(', ')}`);
+  } else if (type === 'invalid-file-format') {
+    console.error(`The following files are not accepted formats: ${files.map(file => file.name).join(', ')}`);
   }
 }
 </script>

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -1,0 +1,241 @@
+<template>
+  <div
+    class="preview-container"
+    :class="previewWrapperClasses"
+    v-if="mode === 'drop'"
+  >
+    <slot name="preview" v-for="file in files" :data="file">
+      <div
+        class="preview"
+        :class="{
+          preview__multiple: multiple,
+          preview__file:
+            file && file.file.type && !file.file.type.includes('image/'),
+        }"
+        :style="{
+          width: `${imgWidth} !important`,
+          height: `${imgHeight} !important`,
+        }"
+      >
+        <img
+          :src="file.src"
+          :alt="file.file.name"
+          v-if="file && file.file.type && file.file.type.includes('image/')"
+        />
+        <Icon
+          :name="file.file.name.split('.').pop()"
+          v-if="
+            (file && file.file.type && !file.file.type.includes('image/')) ||
+            (file && file.file.type && !file.file.type.includes('video/'))
+          "
+        />
+        <div class="img-details" v-if="file.file.name || file.file.size">
+          <button class="img-remove" @click="removeFile(file)">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="icon icon-tabler icons-tabler-outline icon-tabler-x"
+            >
+              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+              <path d="M18 6l-12 12" />
+              <path d="M6 6l12 12" />
+            </svg>
+          </button>
+          <h2>{{ file.file.name }}</h2>
+          <span>{{ formatSize(file.file.size) }}</span>
+        </div>
+      </div>
+    </slot>
+  </div>
+  <div
+    class="preview-container"
+    :class="previewWrapperClasses"
+    v-if="mode === 'preview'"
+  >
+    <template v-for="file in previewUrls">
+      <div
+        class="preview"
+        :class="{ preview__multiple: previewUrls.length > 1 }"
+        :style="{
+          width: `${imgWidth} !important`,
+          height: `${imgHeight} !important`,
+        }"
+      >
+        <img :src="file.src" />
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { defineExpose, ref, watchEffect } from "vue";
+import Icon from "./Icon.vue";
+
+const props = defineProps({
+  files: {
+    type: Array,
+    default: [],
+  },
+  previewUrls: {
+    type: Array,
+    default: [],
+  },
+  multiple: {
+    type: Boolean,
+    default: false,
+  },
+  mode: {
+    type: String,
+    default: "drop",
+    validator(value) {
+      return ["drop", "preview"].includes(value);
+    },
+  },
+  imgWidth: [Number, String],
+  imgHeight: [Number, String],
+  previewWrapperClasses: String,
+});
+
+const emit = defineEmits(["removeFile"]);
+
+// Formats file size
+const formatSize = (size) => {
+  const i = Math.floor(Math.log(size) / Math.log(1024));
+  return (
+    (size / Math.pow(1024, i)).toFixed(2) * 1 + " " + ["B", "KB", "MB", "GB"][i]
+  );
+};
+
+// Removes file from files list
+const removeFile = (item) => {
+  emit("removeFile", item);
+};
+</script>
+
+<style scoped>
+.preview-container {
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 40px;
+}
+
+.preview {
+  width: 100%;
+  height: 95%;
+  border-radius: 8px;
+  flex-shrink: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview__multiple {
+  height: 90% !important;
+  width: 90% !important;
+}
+
+.preview__file {
+  border: 1px dashed rgba(var(--v3-dropzone--primary));
+}
+
+.preview__file--error {
+  border-color: rgba(var(--v3-dropzone--error)) !important;
+}
+
+.preview:hover .img-details {
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+.preview img {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+}
+
+.img-details {
+  position: absolute;
+  top: 0;
+  inset-inline-start: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(
+    var(--v3-dropzone--overlay),
+    var(--v3-dropzone--overlay-opacity)
+  );
+  border-radius: 8px;
+  transition: all 0.2s linear;
+  -webkit-backdrop-filter: blur(7px);
+  backdrop-filter: blur(7px);
+  filter: grayscale(1%);
+  opacity: 0;
+  visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.img-details h2 {
+  font-size: 14px;
+  font-weight: 400;
+  text-align: center;
+  color: #fff;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 400px) {
+  .img-details h2 {
+    max-width: 200px;
+  }
+}
+
+.img-details span {
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+  color: #fff;
+}
+
+.img-remove {
+  background: rgba(var(--v3-dropzone--error));
+  border-radius: 10px;
+  border: none;
+  padding: 5px;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  transition: all 0.2s linear;
+}
+
+.img-remove:active {
+  transform: scale(0.9);
+}
+
+.img-remove:hover {
+  background: rgba(var(--v3-dropzone--error), 0.8);
+}
+</style>

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -4,7 +4,13 @@
     :class="previewWrapperClasses"
     v-if="mode === 'drop'"
   >
-    <slot name="preview" v-for="file in files" :data="file">
+    <slot
+      name="preview"
+      v-for="file in files"
+      :data="file"
+      :formatSize="formatSize"
+      :removeFile="removeFile"
+    >
       <div
         class="preview"
         :class="{

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -57,6 +57,20 @@
           <h2>{{ file.file.name }}</h2>
           <span>{{ formatSize(file.file.size) }}</span>
         </div>
+        <div
+          class="progress-bar-container"
+          v-if="file.status === 'pending' || file.status === 'uploading'"
+        >
+          <div
+            class="progress-bar"
+            :aria-valuenow="file.progress"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :style="{ width: `${file.progress}%` }"
+          >
+            {{ file.progress }}%
+          </div>
+        </div>
       </div>
     </slot>
   </div>
@@ -243,5 +257,26 @@ const removeFile = (item) => {
 
 .img-remove:hover {
   background: rgba(var(--v3-dropzone--error), 0.8);
+}
+
+.progress-bar-container {
+  position: absolute;
+  bottom: 0;
+  background-color: #666;
+  border-radius: 5px;
+  overflow: hidden;
+  width: 100%;
+  height: 10px;
+}
+
+.progress-bar {
+  height: 100%;
+  background-color: rgba(var(--v3-dropzone--primary));
+  text-align: center;
+  font-size: 10px;
+  line-height: 10px;
+  color: #fff;
+  width: 0;
+  transition: width 0.5s ease-in-out;
 }
 </style>

--- a/src/components/Vue3Dropzone.vue
+++ b/src/components/Vue3Dropzone.vue
@@ -69,7 +69,16 @@
         :imgHeight="imgHeight"
         :previewWrapperClasses="previewWrapperClasses"
         @removeFile="removeFile"
-      />
+      >
+        <template #preview="{ data, formatSize, removeFile }">
+          <slot
+            name="preview"
+            :data="data"
+            :formatSize="formatSize"
+            :removeFile="removeFile"
+          ></slot>
+        </template>
+      </Preview>
     </div>
     <div
       class="dropzone-wrapper__disabled"

--- a/src/components/Vue3Dropzone.vue
+++ b/src/components/Vue3Dropzone.vue
@@ -59,85 +59,17 @@
       </template>
 
       <!--   Files previews   -->
-      <template v-else>
-        <div
-          class="preview-container"
-          :class="previewWrapperClasses"
-          v-if="mode === 'drop'"
-        >
-          <slot name="preview" v-for="file in files" :data="file">
-            <div
-              class="preview"
-              :class="{
-                preview__multiple: multiple,
-                preview__file:
-                  file && file.file.type && !file.file.type.includes('image/'),
-              }"
-              :style="{
-                width: `${imgWidth} !important`,
-                height: `${imgHeight} !important`,
-              }"
-            >
-              <img
-                :src="file.src"
-                :alt="file.file.name"
-                v-if="
-                  file && file.file.type && file.file.type.includes('image/')
-                "
-              />
-              <Icon
-                :name="file.file.name.split('.').pop()"
-                v-if="
-                  (file &&
-                    file.file.type &&
-                    !file.file.type.includes('image/')) ||
-                  (file && file.file.type && !file.file.type.includes('video/'))
-                "
-              />
-              <div class="img-details" v-if="file.file.name || file.file.size">
-                <button class="img-remove" @click="removeFile(file)">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    class="icon icon-tabler icons-tabler-outline icon-tabler-x"
-                  >
-                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                    <path d="M18 6l-12 12" />
-                    <path d="M6 6l12 12" />
-                  </svg>
-                </button>
-                <h2>{{ file.file.name }}</h2>
-                <span>{{ formatSize(file.file.size) }}</span>
-              </div>
-            </div>
-          </slot>
-        </div>
-        <div
-          class="preview-container"
-          :class="previewWrapperClasses"
-          v-if="mode === 'preview'"
-        >
-          <template v-for="file in previewUrls">
-            <div
-              class="preview"
-              :class="{ preview__multiple: previewUrls.length > 1 }"
-              :style="{
-                width: `${imgWidth} !important`,
-                height: `${imgHeight} !important`,
-              }"
-            >
-              <img :src="file.src" />
-            </div>
-          </template>
-        </div>
-      </template>
+      <Preview
+        v-else
+        :files="files"
+        :previewUrls="previewUrls"
+        :multiple="multiple"
+        :mode="mode"
+        :imgWidth="imgWidth"
+        :imgHeight="imgHeight"
+        :previewWrapperClasses="previewWrapperClasses"
+        @removeFile="removeFile"
+      />
     </div>
     <div
       class="dropzone-wrapper__disabled"
@@ -151,8 +83,8 @@
 
 <script setup>
 import { computed, defineExpose, ref, watchEffect } from "vue";
-import Icon from "./Icon.vue";
 import PlaceholderImage from "./PlaceholderImage.vue";
+import Preview from "./Preview.vue";
 
 const props = defineProps({
   modelValue: {
@@ -368,14 +300,6 @@ const uploadFileToServer = (fileItem) => {
   xhr.send(formData);
 };
 
-// Formats file size
-const formatSize = (size) => {
-  const i = Math.floor(Math.log(size) / Math.log(1024));
-  return (
-    (size / Math.pow(1024, i)).toFixed(2) * 1 + " " + ["B", "KB", "MB", "GB"][i]
-  );
-};
-
 // Toggles active state for dropping files(styles)
 const toggleActive = () => {
   if (!props.disabled && props.mode !== "preview") {
@@ -557,124 +481,5 @@ defineExpose({
 .titles h3 {
   margin-top: 30px;
   font-weight: 400;
-}
-
-.preview-container {
-  width: 100%;
-  height: 100%;
-  overflow-y: auto;
-  overflow-x: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 40px;
-}
-
-.preview {
-  width: 100%;
-  height: 95%;
-  border-radius: 8px;
-  flex-shrink: 0;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.preview__multiple {
-  height: 90% !important;
-  width: 90% !important;
-}
-
-.preview__file {
-  border: 1px dashed rgba(var(--v3-dropzone--primary));
-}
-
-.preview__file--error {
-  border-color: rgba(var(--v3-dropzone--error)) !important;
-}
-
-.preview:hover .img-details {
-  opacity: 1 !important;
-  visibility: visible !important;
-}
-
-.preview img {
-  width: 100%;
-  height: 100%;
-  border-radius: 8px;
-}
-
-.img-details {
-  position: absolute;
-  top: 0;
-  inset-inline-start: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(
-    var(--v3-dropzone--overlay),
-    var(--v3-dropzone--overlay-opacity)
-  );
-  border-radius: 8px;
-  transition: all 0.2s linear;
-  -webkit-backdrop-filter: blur(7px);
-  backdrop-filter: blur(7px);
-  filter: grayscale(1%);
-  opacity: 0;
-  visibility: hidden;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-}
-
-.img-details h2 {
-  font-size: 14px;
-  font-weight: 400;
-  text-align: center;
-  color: #fff;
-  max-width: 40%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-@media (max-width: 400px) {
-  .img-details h2 {
-    max-width: 200px;
-  }
-}
-
-.img-details span {
-  font-size: 12px;
-  font-weight: 600;
-  text-align: center;
-  color: #fff;
-}
-
-.img-remove {
-  background: rgba(var(--v3-dropzone--error));
-  border-radius: 10px;
-  border: none;
-  padding: 5px;
-  color: #fff;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  transition: all 0.2s linear;
-}
-
-.img-remove:active {
-  transform: scale(0.9);
-}
-
-.img-remove:hover {
-  background: rgba(var(--v3-dropzone--error), 0.8);
 }
 </style>


### PR DESCRIPTION
- Moved the preview logic to a child component, allowing for easier customization of the preview slot from the parent component.
- Added a detailed section on how to override the `preview` slot, including the props available for customization.
- Introduced a new section explaining how to enable server-side file uploads, including a table detailing the relevant props (`server-side`, `endpoint`, `headers`) and their functions.
- Provided examples for both the `preview` slot and server-side upload configuration to improve usability and understanding.