### PR TITLE
Improvements to the preview component

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,23 +55,24 @@ Local registration:
 
 ## Props
 
-| Prop                    | Type              | Default   | Note                                                                  |
-| ----------------------- | ----------------- | --------- | --------------------------------------------------------------------- |
-| `modelValue`            | `Array`           | []        | 2 way binding ref                                                     |
-| `multiple`              | `Boolean`         | false     | Makes dropzone accept multiple files                                  |
-| `previews`              | `Array`           | []        | Preview images links (works with mode props)                          |
-| `mode`                  | `string`          | drop      | Defines dropzone functionality to accept drops or just preview images |
-| `disabled`              | `Boolean`         | false     | Disables the whole dropzone                                           |
-| `accept`                | `String`          | undefined | Accepted type of files                                                |
-| `maxFileSize`           | `Number`          | 5         | Max file size in Megabytes                                            |
-| `maxFiles`              | `Number`          | 5         | Max files accepted by dropzone                                        |
-| `width`                 | `Number` `String` | undefined | Dropzone container width                                              |
-| `height`                | `Number` `String` | undefined | Dropzone container height                                             |
-| `imgWidth`              | `Number` `String` | undefined | Preview images width                                                  |
-| `imgHeight`             | `Number` `String` | undefined | Preview images height                                                 |
-| `previewWrapperClasses` | `String`          | undefined | Preview images container classes                                      |
-| `showSelectButton`      | `Boolean`         | true      | Select files button in the dropzone                                   |
-| `selectFileStrategy`    | `String`          | 'replace' | Defines selecting file strategy (replace, merge)                      |
+| Prop                    | Type              | Default         | Note                                                                  |
+| ----------------------- | ----------------- | --------------- | --------------------------------------------------------------------- |
+| `modelValue`            | `Array`           | []              | 2 way binding ref                                                     |
+| `multiple`              | `Boolean`         | false           | Makes dropzone accept multiple files                                  |
+| `previews`              | `Array`           | []              | Preview images links (works with mode props)                          |
+| `mode`                  | `string`          | drop            | Defines dropzone functionality to accept drops or just preview images |
+| `disabled`              | `Boolean`         | false           | Disables the whole dropzone                                           |
+| `accept`                | `String`          | undefined       | Accepted type of files                                                |
+| `maxFileSize`           | `Number`          | 5               | Max file size in Megabytes                                            |
+| `maxFiles`              | `Number`          | 5               | Max files accepted by dropzone                                        |
+| `width`                 | `Number` `String` | undefined       | Dropzone container width                                              |
+| `height`                | `Number` `String` | undefined       | Dropzone container height                                             |
+| `imgWidth`              | `Number` `String` | undefined       | Preview images width                                                  |
+| `imgHeight`             | `Number` `String` | undefined       | Preview images height                                                 |
+| `previewWrapperClasses` | `String`          | undefined       | Preview images container classes                                      |
+| `previewPosition`       | `String`          | inside, outside | Preview images position                                               |
+| `showSelectButton`      | `Boolean`         | true            | Select files button in the dropzone                                   |
+| `selectFileStrategy`    | `String`          | 'replace'       | Defines selecting file strategy (replace, merge)                      |
 
 ## Server-Side File Upload
 

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -145,26 +145,28 @@ const removeFile = (item) => {
   overflow-y: auto;
   overflow-x: hidden;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: flex-start;
+  justify-content: flex-start;
   flex-wrap: wrap;
   gap: 40px;
 }
 
 .preview {
   width: 100%;
-  height: 95%;
+  height: 100%;
   border-radius: 8px;
   flex-shrink: 0;
   position: relative;
   display: flex;
   align-items: center;
+  flex-direction: column;
   justify-content: center;
+  overflow: hidden;
 }
 
 .preview__multiple {
-  height: 90% !important;
-  width: 90% !important;
+  height: 150px;
+  width: 150px;
 }
 
 .preview__file {
@@ -184,6 +186,7 @@ const removeFile = (item) => {
   width: 100%;
   height: 100%;
   border-radius: 8px;
+  object-fit: cover;
 }
 
 .img-details {

--- a/src/components/PreviewSlot.vue
+++ b/src/components/PreviewSlot.vue
@@ -1,0 +1,29 @@
+<template>
+    <Preview v-bind="previewProps">
+        <template #preview="slotProps">
+            <slot name="preview" v-bind="slotProps"></slot>
+        </template>
+    </Preview>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import Preview from './Preview.vue';
+
+const props = defineProps({
+    files: Array,
+    previewUrls: Array,
+    multiple: Boolean,
+    mode: String,
+    imgWidth: [Number, String],
+    imgHeight: [Number, String],
+    previewWrapperClasses: [String, Array, Object]
+});
+
+const emit = defineEmits(['removeFile']);
+
+const previewProps = computed(() => ({
+    ...props,
+    onRemoveFile: (file) => emit('removeFile', file)
+}));
+</script>

--- a/src/components/Vue3Dropzone.vue
+++ b/src/components/Vue3Dropzone.vue
@@ -59,26 +59,13 @@
       </template>
 
       <!--   Files previews   -->
-      <Preview
-        v-else
-        :files="files"
-        :previewUrls="previewUrls"
-        :multiple="multiple"
-        :mode="mode"
-        :imgWidth="imgWidth"
-        :imgHeight="imgHeight"
-        :previewWrapperClasses="previewWrapperClasses"
-        @removeFile="removeFile"
-      >
-        <template #preview="{ data, formatSize, removeFile }">
-          <slot
-            name="preview"
-            :data="data"
-            :formatSize="formatSize"
-            :removeFile="removeFile"
-          ></slot>
-        </template>
-      </Preview>
+      <template v-else>
+        <PreviewSlot v-bind="previewProps" @removeFile="removeFile">
+          <template #preview="previewProps">
+            <slot name="preview" v-bind="previewProps"></slot>
+          </template>
+        </PreviewSlot>
+      </template>
     </div>
     <div
       class="dropzone-wrapper__disabled"
@@ -93,7 +80,7 @@
 <script setup>
 import { computed, defineExpose, ref, watchEffect } from "vue";
 import PlaceholderImage from "./PlaceholderImage.vue";
-import Preview from "./Preview.vue";
+import PreviewSlot from "./PreviewSlot.vue";
 
 const props = defineProps({
   modelValue: {
@@ -169,6 +156,17 @@ const props = defineProps({
     default: () => ({}),
   },
 });
+
+const previewProps = computed(() => ({
+  files: files.value,
+  previewUrls: previewUrls.value,
+  multiple: props.multiple,
+  mode: props.mode,
+  imgWidth: props.imgWidth,
+  imgHeight: props.imgHeight,
+  previewWrapperClasses: props.previewWrapperClasses,
+}));
+
 const emit = defineEmits([
   "drop",
   "update:modelValue",

--- a/src/components/Vue3Dropzone.vue
+++ b/src/components/Vue3Dropzone.vue
@@ -20,7 +20,7 @@
       @click.self="openSelectFile"
       id="dropzoneWrapper"
     >
-      <!--   Input   -->
+      <!-- Input -->
       <input
         type="file"
         ref="fileInput"
@@ -31,8 +31,8 @@
         :multiple="multiple"
       />
 
-      <!--   Placeholder content   -->
-      <template v-if="!previewUrls.length">
+      <!-- Placeholder content -->
+      <template v-if="!previewUrls.length || previewPosition === 'outside'">
         <slot name="placeholder-img">
           <PlaceholderImage />
         </slot>
@@ -58,14 +58,16 @@
         </slot>
       </template>
 
-      <!--   Files previews   -->
-      <template v-else>
-        <PreviewSlot v-bind="previewProps" @removeFile="removeFile">
-          <template #preview="previewProps">
-            <slot name="preview" v-bind="previewProps"></slot>
-          </template>
-        </PreviewSlot>
-      </template>
+      <!-- Files previews inside -->
+      <PreviewSlot
+        v-if="previewPosition === 'inside'"
+        v-bind="previewProps"
+        @removeFile="removeFile"
+      >
+        <template #preview="previewProps">
+          <slot name="preview" v-bind="previewProps"></slot>
+        </template>
+      </PreviewSlot>
     </div>
     <div
       class="dropzone-wrapper__disabled"
@@ -74,6 +76,15 @@
       @dragover.prevent
       v-if="disabled"
     ></div>
+
+    <!-- Files previews outside -->
+    <div class="mt-5" v-if="previewPosition === 'outside'">
+      <PreviewSlot v-bind="previewProps" @removeFile="removeFile">
+        <template #preview="previewProps">
+          <slot name="preview" v-bind="previewProps"></slot>
+        </template>
+      </PreviewSlot>
+    </div>
   </div>
 </template>
 
@@ -127,6 +138,11 @@ const props = defineProps({
   imgHeight: [Number, String],
   fileInputId: String,
   previewWrapperClasses: String,
+  previewPosition: {
+    type: String,
+    default: "inside",
+    validator: (value) => ["inside", "outside"].includes(value),
+  },
   showSelectButton: {
     type: Boolean,
     default: true,
@@ -442,6 +458,10 @@ defineExpose({
 
 .m-0 {
   margin: 0;
+}
+
+.mt-5 {
+  margin-top: 3rem;
 }
 
 .dropzone {


### PR DESCRIPTION
**Adjust image display in preview container**

- Updated CSS to allow images to fit within the preview container without distortion.
- Set max-width and max-height for preview items to 150px, ensuring consistent sizing.
- Used object-fit property to maintain image aspect ratio while filling the container.

<img width="1160" alt="Screenshot 2024-11-02 at 3 20 23 AM" src="https://github.com/user-attachments/assets/afbe799a-501b-4a22-8a58-d11756aa0995">

**Refactor Preview component for better reusability**

- Create new PreviewSlot component to encapsulate Preview logic
- Reduce code duplication when using Preview in different positions
- Added new previewPosition prop with options inside and outside to control file preview placement within or outside the container.
<img width="1169" alt="Screenshot 2024-11-02 at 4 00 43 AM" src="https://github.com/user-attachments/assets/2e5360bc-e21a-46cb-ad46-274374e7ab5c">
